### PR TITLE
feat: throw cause as error

### DIFF
--- a/src/field-builder.ts
+++ b/src/field-builder.ts
@@ -64,8 +64,13 @@ fieldBuilderProto.effect = function effect({ effect = {}, resolve, ...options })
         }
       }
 
-      if (Exit.isFailure(result) && Cause.isAnnotatedType(result.cause) && Cause.isFailType(result.cause.cause)) {
-        throw result.cause.cause.error;
+      if (Exit.isFailure(result)) {
+        if (Cause.isAnnotatedType(result.cause) && Cause.isFailType(result.cause.cause)) {
+          throw result.cause.cause.error;
+        }
+        throw new (effect.failErrorConstructor ?? effectOptions?.failErrorConstructor ?? Error)(
+          Cause.pretty(result.cause),
+        );
       }
 
       throw result as never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,7 @@ export type FieldOptions<
   & {
     effect?: {
       contexts?: ContextsShape;
+      failErrorConstructor?: { new(message: string): unknown };
       layers?: LayersShape;
       services?: ServiceEntriesShape;
     };
@@ -139,6 +140,7 @@ export type FieldOptions<
   };
 
 export type PluginOptions<Types extends SchemaTypes> = EmptyToOptional<{
+  failErrorConstructor?: { new(message: string): unknown };
   globalContext?: ((conext: Types['Context']) => Types['EffectGlobalContext']) | Types['EffectGlobalContext'];
   globalLayer?: ((conext: Types['Context']) => Types['EffectGlobalLayer']) | Types['EffectGlobalLayer'];
 }>;


### PR DESCRIPTION
Before this patch, having other `Cause`s than `Fail` resulted in a `NonErrorThrown` error, thrown by the `graphql` package.
This was very inconvenient to debug the cause of effect failures, especially since all the useful information like stacktrace was not available.
This PR fixes the problem by wrapping the prettified `Cause` with an error constructor. (`Error` by default, globally and locally customizable)