### PR TITLE
refactor: replace the use of option.match with option.getOrElse where possible

### DIFF
--- a/src/field-builder.ts
+++ b/src/field-builder.ts
@@ -1,5 +1,5 @@
 import * as Context from '@effect/data/Context';
-import { pipe } from '@effect/data/Function';
+import { pipe, constNull } from '@effect/data/Function';
 import * as Option from '@effect/data/Option';
 import * as Cause from '@effect/io/Cause';
 import * as Effect from '@effect/io/Effect';
@@ -50,10 +50,7 @@ fieldBuilderProto.effect = function effect({ effect = {}, resolve, ...options })
         }
 
         if (Array.isArray(result.value)) {
-          return result.value.map(Option.match({
-            onNone: () => null,
-            onSome: (value) => value,
-          }));
+          return result.value.map(Option.getOrElse(constNull));
         }
 
         if (Option.isOption(result.value)) {
@@ -61,10 +58,7 @@ fieldBuilderProto.effect = function effect({ effect = {}, resolve, ...options })
             onNone: () => null,
             onSome: (value) => {
               if (typeof options.nullable === 'object' && options.nullable.items && Array.isArray(value)) {
-                return value.map(Option.match({
-                  onNone: () => null,
-                  onSome: (value) => value,
-                }));
+                return value.map(Option.getOrElse(constNull));
               }
 
               return value;


### PR DESCRIPTION
I'm getting a bit familiar with this project and I found a minuscule improvement I could make around the use of `Option.match`. When `onSome` is an identity function, it can be replaced by `Option.getOrElse`.

Also, `() => null` can be replaced by `constNull` as provided by `@effect/data`.