### PR TITLE
add basic t.effectConnection implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@pothos/core": "^3.30.0",
     "@pothos/plugin-errors": "^3.11.1",
+    "@pothos/plugin-relay": "^3.43.0",
     "@swc/core": "^1.3.69",
     "@swc/jest": "^0.2.26",
     "@types/jest": "^29.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@pothos/plugin-errors':
         specifier: ^3.11.1
         version: 3.11.1(@pothos/core@3.30.0)(graphql@16.7.1)
+      '@pothos/plugin-relay':
+        specifier: ^3.43.0
+        version: 3.43.0(@pothos/core@3.30.0)(graphql@16.7.1)
       '@swc/core':
         specifier: ^1.3.69
         version: 1.3.69
@@ -1441,6 +1444,16 @@ packages:
 
   /@pothos/plugin-errors@3.11.1(@pothos/core@3.30.0)(graphql@16.7.1):
     resolution: {integrity: sha512-ty+L1yfGartuuIMszGZyDQtzwpt/7ijVbnmGfOZdcQZOlk1P0MUr1iJ56Z5QhaHwZuwyVBF17gwP7ZroGs9htg==}
+    peerDependencies:
+      '@pothos/core': '*'
+      graphql: '>=15.1.0'
+    dependencies:
+      '@pothos/core': 3.30.0(graphql@16.7.1)
+      graphql: 16.7.1
+    dev: true
+
+  /@pothos/plugin-relay@3.43.0(@pothos/core@3.30.0)(graphql@16.7.1):
+    resolution: {integrity: sha512-435jODSgj29IRgHlQjfLUoaTcg1FodqkOaNA0T0IZmjgmS8+2GxqYscRrZWQU7Ufr1MLRvGXOQ+14ri2jw5geQ==}
     peerDependencies:
       '@pothos/core': '*'
       graphql: '>=15.1.0'

--- a/src/global-types.ts
+++ b/src/global-types.ts
@@ -1,5 +1,19 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import type { FieldKind, FieldNullability, FieldRef, InputFieldMap, SchemaTypes, TypeParam } from '@pothos/core';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-empty-interface */
+import type {
+  FieldKind,
+  FieldNullability,
+  FieldRef,
+  InputFieldMap,
+  InterfaceParam,
+  NormalizeArgs,
+  OutputType,
+  PluginName,
+  SchemaTypes,
+  ShapeFromTypeParam,
+  TypeParam,
+} from '@pothos/core';
 import type { Context, Layer } from 'effect';
 
 import type { EffectPlugin } from './index.js';
@@ -58,6 +72,108 @@ declare global {
           ErrorsShape
         >,
       ) => FieldRef<unknown>;
+
+      effectConnection: 'relay' extends PluginName ? <
+          Type extends OutputType<Types>,
+          Nullable extends boolean,
+          ResolveReturnShape,
+          // Effect Types:
+          ServiceEntriesShape extends readonly [...EffectPluginTypes.ServiceEntry[]],
+          ContextsShape extends readonly [...EffectPluginTypes.Context[]],
+          LayersShape extends readonly [...EffectPluginTypes.Layer[]],
+          ErrorsShape extends readonly [...any[]],
+          // Relay Types:
+          Args extends InputFieldMap = {},
+          ConnectionInterfaces extends InterfaceParam<Types>[] = [],
+          EdgeInterfaces extends InterfaceParam<Types>[] = [],
+        >(
+          options: EffectPluginTypes.ConnectionFieldOptions<
+            Types,
+            ParentShape,
+            Type,
+            Args,
+            Nullable,
+            ResolveReturnShape,
+            ServiceEntriesShape,
+            ContextsShape,
+            LayersShape,
+            ErrorsShape,
+            Kind
+          >,
+          ...args: NormalizeArgs<
+            [
+              connectionOptions:
+                | ConnectionObjectOptions<
+                  Types,
+                  Type,
+                  false,
+                  false,
+                  ResolveReturnShape,
+                  ConnectionInterfaces
+                >
+                | ObjectRef<
+                  EffectPluginTypes.ShapeFromConnection<
+                    ConnectionShapeHelper<Types, ShapeFromTypeParam<Types, Type, false>, false>
+                  >
+                >,
+              edgeOptions:
+                | ConnectionEdgeObjectOptions<
+                  Types,
+                  Type,
+                  false,
+                  ResolveReturnShape,
+                  EdgeInterfaces
+                >
+                | ObjectRef<{
+                  cursor: string;
+                  node?: ShapeFromTypeParam<Types, Type, false> | null | undefined;
+                }>,
+            ],
+            0
+          >
+        ) => FieldRef<
+          EffectPluginTypes.ShapeFromConnection<
+            ConnectionShapeHelper<Types, ShapeFromTypeParam<Types, Type, false>, Nullable>
+          >
+        >
+        : '@pothos/plugin-relay is required to use this method';
     }
+
+    export interface ConnectionShapeHelper<Types extends SchemaTypes, T, Nullable> {}
+
+    export interface DefaultConnectionArguments {
+      after?: null | string | undefined;
+      before?: null | string | undefined;
+      first?: null | number | undefined;
+      last?: null | number | undefined;
+    }
+
+    export interface ConnectionFieldOptions<
+      Types extends SchemaTypes,
+      ParentShape,
+      Type extends OutputType<Types>,
+      Nullable extends boolean,
+      EdgeNullability extends FieldNullability<[unknown]>,
+      NodeNullability extends boolean,
+      Args extends InputFieldMap,
+      ResolveReturnShape,
+    > {}
+
+    export interface ConnectionObjectOptions<
+      Types extends SchemaTypes,
+      Type extends OutputType<Types>,
+      EdgeNullability extends FieldNullability<[unknown]>,
+      NodeNullability extends boolean,
+      Resolved,
+      Interfaces extends InterfaceParam<Types>[] = [],
+    > {}
+
+    export interface ConnectionEdgeObjectOptions<
+      Types extends SchemaTypes,
+      Type extends OutputType<Types>,
+      NodeNullability extends boolean,
+      Resolved,
+      Interfaces extends InterfaceParam<Types>[] = [],
+    > {}
   }
 }


### PR DESCRIPTION
Got some questions about how to integrate the effect and relay plugins.  Getting connections working with more complex field builders is a bit more involved, and requires the other plugin to specifically build out a connection method (you can work around it, but its a lot easier if the plugin supports it directly). 

The strategies for interoperability are not really documented, and not at all obvious, so I wanted to open this PR as a starting place for supporting connections in the effect plugin

related to #3 